### PR TITLE
Fix blank render for in-memory stores

### DIFF
--- a/src/store/createPughStore.ts
+++ b/src/store/createPughStore.ts
@@ -69,6 +69,12 @@ export function createPughStore(options: CreatePughStoreOptions = {}) {
     repository = createMemoryRepository(),
   } = options;
 
+  // When no external repository is provided, seed data is projected
+  // synchronously and we can render immediately without waiting for init().
+  // External repositories (e.g. localStorage) may contain persisted state
+  // that differs from seed data, so they must hydrate asynchronously.
+  const hasExternalRepository = options.repository != null;
+
   const initialEvents = seedEventsFromOptions({ criteria, options: opts, ratings, weights });
   const initialDomain = projectEvents(initialEvents);
 
@@ -112,7 +118,7 @@ export function createPughStore(options: CreatePughStoreOptions = {}) {
       activeBranch: 'main',
       branchNames: ['main'],
       commitLog: [],
-      isLoading: true,
+      isLoading: hasExternalRepository,
       comparingBranch: null,
       branchDiff: null,
 
@@ -185,6 +191,9 @@ export function createPughStore(options: CreatePughStoreOptions = {}) {
               set({ events, ...domain, commitLog, branchNames, activeBranch: 'main', isLoading: false }, false, 'init/hydrate');
             }
           } else {
+            // No existing ref — seed the repo. If we already rendered
+            // synchronously (in-memory repo), this just populates the
+            // repository for future mutations without blocking the UI.
             await seedFresh();
           }
         } catch {


### PR DESCRIPTION
## Summary

- Fixes the "Loading matrix..." → blank screen issue when using `createPughStore` without an external repository
- Stores with no `repository` option (default in-memory) now render synchronously on first paint
- External repositories (localStorage, etc.) still hydrate asynchronously as before

## Problem

`PughStoreProvider` renders `null` until the async `init()` completes:

```tsx
{isLoading ? null : children}
```

Even with the in-memory repository, `init()` is async — it commits seed events through `await repository.commit(...)` which uses microtask-queued promises (the memory store wraps synchronous Map operations in `async` methods). This causes at least one blank frame, and in production builds the component can fail to appear entirely.

## Fix

`createPughStore` already projects seed data synchronously (`projectEvents(initialEvents)`) and spreads it into the initial store state. The only thing blocking render was `isLoading: true`.

Now: when no external `repository` is provided, the store starts with `isLoading: false`. The `init()` still runs (via `useEffect`) to populate the repository for future mutations, but it no longer gates the first render.

## Test plan

- [x] All 114 existing tests pass
- [ ] Verify in-memory matrix renders immediately (no blank flash) in Storybook
- [ ] Verify localStorage-persisted matrix still hydrates correctly
- [ ] Verify in consumer Docusaurus site (the original bug report)

🤖 Generated with [Claude Code](https://claude.com/claude-code)